### PR TITLE
Fix warning about 'loaded resource as image' when adding scenes to dock'

### DIFF
--- a/scripts/scene_library.gd
+++ b/scripts/scene_library.gd
@@ -1099,8 +1099,8 @@ func _get_thumbnail(asset: Dictionary) -> Dictionary:
 		new_thumb["small"] = ImageTexture.create_from_image(image)
 
 	else:
-		new_thumb["large"] = ImageTexture.create_from_image(Image.load_from_file("res://addons/scene-library/icons/thumb_large.svg"))
-		new_thumb["small"] = ImageTexture.create_from_image(Image.load_from_file("res://addons/scene-library/icons/thumb_small.svg"))
+		new_thumb["large"] = ImageTexture.create_from_image(Image.load_from_file(ProjectSettings.globalize_path("res://addons/scene-library/icons/thumb_large.svg")))
+		new_thumb["small"] = ImageTexture.create_from_image(Image.load_from_file(ProjectSettings.globalize_path("res://addons/scene-library/icons/thumb_small.svg")))
 
 		_queue_update_thumbnail(id)
 


### PR DESCRIPTION
![image load error](https://github.com/user-attachments/assets/9fbcef84-6d38-47c6-aa62-ab50b4fd994c)

Fix annoying warnings every time you add new scenes to the collection.

This is a very common issue with addons. 
The simple way to avoid this is to pass the image string  with `ProjectSettings.globalize_path`.


----
PS:
Incredibly useful addon!
It's a must-have for almost every project. Great work!
Godot core should have this. At the very least the thumbnail generation for gltf's.
