### PR TITLE
Remove small thumbnail

### DIFF
--- a/icons/thumb_large.svg
+++ b/icons/thumb_large.svg
@@ -1,1 +1,0 @@
-<svg viewBox="0 0 192 192" xmlns="http://www.w3.org/2000/svg"><path d="m12 12v168h168V12m-60.666 84 42 56H30.664l32.668-42 23.332 28" fill="#fff"/></svg>

--- a/icons/thumb_placeholder.svg
+++ b/icons/thumb_placeholder.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192">
+	<path fill="#ccc" d="m24.863 51.73 5.274 89.665 72.375 31.894 57.93-37.187 5.038-87.993-74.902-16.453" />
+	<path fill="none" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="6" d="m24.862 51.731 5.274 89.665 72.375 31.893 57.93-37.186 5.039-87.992-74.903-16.453L24.862 51.73m140.618-3.62-62.372 25.705" />
+	<path fill="none" stroke="black" stroke-width="6" d="m24.862 51.731 78.242 22.086-.593 99.472" />
+</svg>

--- a/icons/thumb_small.svg
+++ b/icons/thumb_small.svg
@@ -1,1 +1,0 @@
-<svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg"><path d="m3 3v42h42V3M29.834 24l10.5 14H7.667l8.167-10.5 5.833 7" fill="#fff"/></svg>

--- a/scripts/scene_library.gd
+++ b/scripts/scene_library.gd
@@ -98,7 +98,7 @@ var _light_3d: DirectionalLight3D = null
 var _asset_display_mode: DisplayMode = DisplayMode.THUMBNAILS
 var _sort_mode: SortMode = SortMode.NAME
 
-var _thumbnails: Dictionary[int, Dictionary] = {} # Dictionary[int, Dictionary[StringName, ImageTexture]]
+var _thumbnails: Dictionary[int, ImageTexture] = {}
 
 var _mutex: Mutex = null
 var _thread: Thread = null
@@ -267,12 +267,13 @@ func _enter_tree() -> void:
 	_top_hbox.add_child(_mode_list_btn)
 
 	_item_list = AssetItemList.new()
-	_item_list.set_v_size_flags(Control.SIZE_EXPAND_FILL)
-	_item_list.set_mouse_filter(Control.MOUSE_FILTER_PASS)
 	_item_list.set_focus_mode(Control.FOCUS_CLICK)
-	_item_list.set_select_mode(ItemList.SELECT_MULTI)
 	_item_list.set_max_columns(0)
+	_item_list.set_mouse_filter(Control.MOUSE_FILTER_PASS)
 	_item_list.set_same_column_width(true)
+	_item_list.set_select_mode(ItemList.SELECT_MULTI)
+	_item_list.set_texture_filter(CanvasItem.TEXTURE_FILTER_LINEAR)
+	_item_list.set_v_size_flags(Control.SIZE_EXPAND_FILL)
 	_item_list.gui_input.connect(_on_item_list_gui_input)
 	_item_list.item_clicked.connect(_on_item_list_item_clicked)
 	_item_list.item_activated.connect(_on_item_list_item_activated)
@@ -521,38 +522,29 @@ func _queue_update_thumbnail(id: int) -> void:
 
 	_thread_sem.post()
 
-func _get_or_create_thumbnail(id: int, path: String) -> Dictionary[StringName, ImageTexture]:
-	if _thumbnails.has(id):
-		return _thumbnails[id]
-
-	var new_thumb: Dictionary[StringName, ImageTexture] = {&"large": null, &"small": null}
-	_thumbnails[id] = new_thumb
+func _get_or_create_thumbnail(id: int, path: String) -> ImageTexture:
+	var thumb: ImageTexture = _thumbnails.get(id, null)
+	if is_instance_valid(thumb):
+		return thumb
 
 	var cache_path: String = _get_thumb_cache_path(path)
-
 	if _cache_enabled and FileAccess.file_exists(cache_path):
-		var image := Image.load_from_file(cache_path)
-		new_thumb[&"large"] = ImageTexture.create_from_image(image)
-
-		image.resize(THUMB_LIST_SIZE, THUMB_LIST_SIZE, Image.INTERPOLATE_LANCZOS)
-		new_thumb[&"small"] = ImageTexture.create_from_image(image)
+		thumb = ImageTexture.create_from_image(Image.load_from_file(cache_path))
+		_thumbnails[id] = thumb
 	else:
-		new_thumb[&"large"] = ImageTexture.create_from_image(Image.load_from_file(ProjectSettings.globalize_path("res://addons/scene-library/icons/thumb_large.svg")))
-		new_thumb[&"small"] = ImageTexture.create_from_image(Image.load_from_file(ProjectSettings.globalize_path("res://addons/scene-library/icons/thumb_small.svg")))
+		thumb = ImageTexture.create_from_image(Image.load_from_file(ProjectSettings.globalize_path("res://addons/scene-library/icons/thumb_large.svg")))
+		_thumbnails[id] = thumb
 
 		_queue_update_thumbnail(id)
 
-	new_thumb.make_read_only()
-	return new_thumb
+	return thumb
 
 func _create_asset(id: int, uid: String, path: String) -> Dictionary[StringName, Variant]:
-	var thumb: Dictionary[StringName, ImageTexture] = _get_or_create_thumbnail(id, path)
 	var asset: Dictionary[StringName, Variant] = {
 		&"id": id,
 		&"uid": uid,
 		&"path": path,
-		&"thumb": thumb[&"large"],
-		&"thumb_small": thumb[&"small"],
+		&"thumb": _get_or_create_thumbnail(id, path),
 	}
 	return asset
 
@@ -668,7 +660,7 @@ func update_item_list() -> void:
 			continue
 
 		_item_list.set_item_text(index, path.get_file().get_basename())
-		_item_list.set_item_icon(index, asset[&"thumb_small"] if is_list_mode else asset[&"thumb"])
+		_item_list.set_item_icon(index, asset[&"thumb"])
 		# NOTE: This tooltip will be hidden because used the custom tooltip.
 		_item_list.set_item_tooltip(index, path)
 		_item_list.set_item_metadata(index, asset)
@@ -1016,18 +1008,15 @@ func _create_thumb(item: Dictionary[StringName, Variant], callback: Callable) ->
 	_viewport.set_update_mode(SubViewport.UPDATE_ONCE)
 
 	await RenderingServer.frame_post_draw
-	var image: Image = _viewport.get_texture().get_image()
 
+	var image: Image = _viewport.get_texture().get_image()
 	image.resize(THUMB_GRID_SIZE, THUMB_GRID_SIZE, Image.INTERPOLATE_LANCZOS)
-	var thumb_large: ImageTexture = item[&"thumb"][&"large"]
-	thumb_large.update(image)
+
+	var thumb: ImageTexture = item[&"thumb"]
+	thumb.update(image)
 
 	if _cache_enabled:
 		_save_thumb_to_disk(item[&"id"], image)
-
-	image.resize(THUMB_LIST_SIZE, THUMB_LIST_SIZE, Image.INTERPOLATE_LANCZOS)
-	var thumb_small: ImageTexture = item[&"thumb"][&"small"]
-	thumb_small.update(image)
 
 	instance.call_deferred(&"free")
 	await instance.tree_exited
@@ -1254,21 +1243,17 @@ func _update_asset_display_mode(display_mode: DisplayMode) -> void:
 		_item_list.set_icon_mode(ItemList.ICON_MODE_TOP)
 		_item_list.set_max_text_lines(2)
 
-		for i: int in _item_list.get_item_count():
-			var asset: Dictionary[StringName, Variant] = _item_list.get_item_metadata(i)
-			_item_list.set_item_icon(i, asset[&"thumb"])
-
 		_mode_thumb_btn.set_pressed_no_signal(true)
 	else:
 		_item_list.set_max_columns(0)
 		_item_list.set_icon_mode(ItemList.ICON_MODE_LEFT)
 		_item_list.set_max_text_lines(1)
 
-		for i: int in _item_list.get_item_count():
-			var asset: Dictionary[StringName, Variant] = _item_list.get_item_metadata(i)
-			_item_list.set_item_icon(i, asset[&"thumb_small"])
-
 		_mode_list_btn.set_pressed_no_signal(true)
+
+	for i: int in _item_list.get_item_count():
+		var asset: Dictionary[StringName, Variant] = _item_list.get_item_metadata(i)
+		_item_list.set_item_icon(i, asset[&"thumb"])
 
 	_update_thumb_icon_size(display_mode)
 

--- a/scripts/scene_library.gd
+++ b/scripts/scene_library.gd
@@ -532,7 +532,7 @@ func _get_or_create_thumbnail(id: int, path: String) -> ImageTexture:
 		thumb = ImageTexture.create_from_image(Image.load_from_file(cache_path))
 		_thumbnails[id] = thumb
 	else:
-		thumb = ImageTexture.create_from_image(Image.load_from_file(ProjectSettings.globalize_path("res://addons/scene-library/icons/thumb_large.svg")))
+		thumb = ImageTexture.create_from_image(Image.load_from_file(ProjectSettings.globalize_path("res://addons/scene-library/icons/thumb_placeholder.svg")))
 		_thumbnails[id] = thumb
 
 		_queue_update_thumbnail(id)


### PR DESCRIPTION
Deletes the small thumbnail and replaces the large one. Also changes the logic of the code, removing the need to generate a small thumbnail.