### PR TITLE
Disable node processing completely to avoid issues with tool scripts

### DIFF
--- a/scripts/scene_library.gd
+++ b/scripts/scene_library.gd
@@ -1036,6 +1036,7 @@ func _create_thumb(item: Dictionary[StringName, Variant], callback: Callable) ->
 		return callback.call()
 
 	var instance: Node = packed_scene.instantiate()
+	_disable_node_processing(instance)
 
 	_viewport.call_deferred(&"add_child", instance)
 	await instance.ready
@@ -1067,6 +1068,12 @@ func _create_thumb(item: Dictionary[StringName, Variant], callback: Callable) ->
 	await instance.tree_exited
 
 	callback.call()
+
+func _disable_node_processing(node: Node) -> void:
+	node.set_process_mode(Node.PROCESS_MODE_DISABLED)
+	
+	for child in node.get_children():
+		_disable_node_processing(child)
 
 func _thread_process() -> void:
 	var semaphore := Semaphore.new()


### PR DESCRIPTION
In my project I have some scenes that don't inherit the processing of their parent, so tool scripts end up running despite the fact that this addon disables the processing of the viewport for generating thumbnails. This can cause a lot of weird issues such as the real scene and thumbnail scene trying to reference nodes from each other causing errors at the engine level.